### PR TITLE
Add prometheus metrics output

### DIFF
--- a/cpuacct.go
+++ b/cpuacct.go
@@ -53,7 +53,7 @@ func (c *cpuacctController) Stat(path string, stats *Stats) error {
 	cpu.Usage.Total = total
 	cpu.Usage.User = user
 	cpu.Usage.Kernel = kernel
-	cpu.Usage.Percpu = percpu
+	cpu.Usage.PerCpu = percpu
 	return nil
 }
 

--- a/cpuset.go
+++ b/cpuset.go
@@ -76,23 +76,6 @@ func (c *cpusetController) getValues(path string) (cpus []byte, mems []byte, err
 	return cpus, mems, nil
 }
 
-func (c *cpusetController) Stat(path string, stats *Stats) error {
-	cpus, mems, err := c.getValues(path)
-	if err != nil {
-		return err
-	}
-	stats.cpuMu.Lock()
-	cpu := stats.Cpu
-	if cpu == nil {
-		cpu = &CpuStat{}
-		stats.Cpu = cpu
-	}
-	cpu.Cpus = string(bytes.Trim(cpus, "\n"))
-	cpu.Mems = string(bytes.Trim(mems, "\n"))
-	stats.cpuMu.Unlock()
-	return nil
-}
-
 // ensureParent makes sure that the parent directory of current is created
 // and populated with the proper cpus and mems files copied from
 // it's parent.

--- a/paths_test.go
+++ b/paths_test.go
@@ -1,6 +1,7 @@
 package cgroups
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,6 +31,22 @@ func TestSelfPath(t *testing.T) {
 	}
 	if p != filepath.Join("/", dp, "test") {
 		t.Fatalf("expected self path of %q but received %q", filepath.Join("/", dp, "test"), p)
+	}
+}
+
+func TestPidPath(t *testing.T) {
+	paths, err := parseCgroupFile("/proc/self/cgroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dp := strings.TrimPrefix(paths["devices"], "/")
+	path := PidPath(os.Getpid())
+	p, err := path("devices")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != filepath.Join("/", dp) {
+		t.Fatalf("expected self path of %q but received %q", filepath.Join("/", dp), p)
 	}
 }
 

--- a/pids.go
+++ b/pids.go
@@ -63,7 +63,7 @@ func (p *pidsController) Stat(path string, stats *Stats) error {
 	}
 	stats.Pids = &PidsStat{
 		Current: current,
-		Max:     max,
+		Limit:   max,
 	}
 	return nil
 }

--- a/prometheus/metrics.go
+++ b/prometheus/metrics.go
@@ -1,0 +1,204 @@
+package prometheus
+
+import (
+	"strconv"
+
+	"github.com/crosbymichael/cgroups"
+	metrics "github.com/docker/go-metrics"
+)
+
+func New(ns *metrics.Namespace) *Collector {
+	// add machine cpus and memory info
+	return &Collector{
+		pidsLimit:   ns.NewLabeledGauge("pids", "The maximum number of pids allowed", metrics.Unit("limit"), "id"),
+		pidsCurrent: ns.NewLabeledGauge("pids", "The current number of pids", metrics.Unit("current"), "id"),
+
+		cpuTotal:            ns.NewLabeledGauge("cpu_total", "The total cpu time", metrics.Nanoseconds, "id"),
+		cpuKernel:           ns.NewLabeledGauge("cpu_kernel", "The total kernel cpu time", metrics.Nanoseconds, "id"),
+		cpuUser:             ns.NewLabeledGauge("cpu_user", "The total user cpu time", metrics.Nanoseconds, "id"),
+		cpuPerCpu:           ns.NewLabeledGauge("per_cpu", "The total cpu time per cpu", metrics.Nanoseconds, "id", "core"),
+		cpuThrottlePeriods:  ns.NewLabeledGauge("cpu_throttle_periods", "The total throttle periods", metrics.Total, "id"),
+		cpuThrottledPeriods: ns.NewLabeledGauge("cpu_throttled_periods", "The total throttled periods", metrics.Total, "id"),
+		cpuThrottledTime:    ns.NewLabeledGauge("cpu_throttled_time", "The total throttled time", metrics.Nanoseconds, "id"),
+
+		memoryCache: ns.NewLabeledGauge("memory_cache", "The cache amount used by the container", metrics.Bytes, "id"),
+
+		memoryUsageFail:  ns.NewLabeledGauge("memory_usage_fail", "The usage failcnt", metrics.Total, "id"),
+		memoryUsageLimit: ns.NewLabeledGauge("memory_usage_limit", "The memory limit", metrics.Bytes, "id"),
+		memoryUsageMax:   ns.NewLabeledGauge("memory_usage_max", "The max memory used", metrics.Bytes, "id"),
+		memoryUsageUsage: ns.NewLabeledGauge("memory_usage_usage", "The current memory used", metrics.Bytes, "id"),
+
+		memorySwapFail:  ns.NewLabeledGauge("memory_swap_fail", "The swap failcnt", metrics.Total, "id"),
+		memorySwapLimit: ns.NewLabeledGauge("memory_swap_limit", "The swap limit", metrics.Bytes, "id"),
+		memorySwapMax:   ns.NewLabeledGauge("memory_swap_max", "The swap memory used", metrics.Bytes, "id"),
+		memorySwapUsage: ns.NewLabeledGauge("memory_swap_usage", "The swap memory used", metrics.Bytes, "id"),
+
+		memoryKernelFail:  ns.NewLabeledGauge("memory_kernel_fail", "The kernel failcnt", metrics.Total, "id"),
+		memoryKernelLimit: ns.NewLabeledGauge("memory_kernel_limit", "The kernel limit", metrics.Bytes, "id"),
+		memoryKernelMax:   ns.NewLabeledGauge("memory_kernel_max", "The kernel memory used", metrics.Bytes, "id"),
+		memoryKernelUsage: ns.NewLabeledGauge("memory_kernel_usage", "The kernel memory used", metrics.Bytes, "id"),
+
+		memoryKernelTCPFail:  ns.NewLabeledGauge("memory_kernel_tcp_fail", "The kernel tcp failcnt", metrics.Total, "id"),
+		memoryKernelTCPLimit: ns.NewLabeledGauge("memory_kernel_tcp_limit", "The kernel tcp limit", metrics.Bytes, "id"),
+		memoryKernelTCPMax:   ns.NewLabeledGauge("memory_kernel_tcp_max", "The kernel tcp memory used", metrics.Bytes, "id"),
+		memoryKernelTCPUsage: ns.NewLabeledGauge("memory_kernel_tcp_usage", "The kernel tcp memory used", metrics.Bytes, "id"),
+
+		hugetlbUsage: ns.NewLabeledGauge("hugetlb_usage", "The hugetlb usage", metrics.Bytes, "id", "page"),
+		hugetlbFail:  ns.NewLabeledGauge("hugetlb_fail", "The hugetlb failcnt", metrics.Total, "id", "page"),
+		hugetlbMax:   ns.NewLabeledGauge("hugetlb_max", "The hugetlb max usage", metrics.Bytes, "id", "page"),
+
+		blkioIOMergedRecursive:       ns.NewLabeledGauge("blkio_io_merged_recursive", "The blkio io merged recursive", metrics.Total, "id", "op", "major", "minor"),
+		blkioIOQueuedRecursive:       ns.NewLabeledGauge("blkio_io_queued_recursive", "The blkio io queued recursive", metrics.Total, "id", "op", "major", "minor"),
+		blkioIOServiceBytesRecursive: ns.NewLabeledGauge("blkio_io_service_bytes_recursive", "The blkio io service bytes recursive", metrics.Bytes, "id", "op", "major", "minor"),
+		blkioIOServiceTimeRecursive:  ns.NewLabeledGauge("blkio_io_service_time_recursive", "The blkio io service time recursive", metrics.Total, "id", "op", "major", "minor"),
+		blkioIOServiedRecursive:      ns.NewLabeledGauge("blkio_io_serviced_recursive", "The blkio io serviced recursive", metrics.Total, "id", "op", "major", "minor"),
+		blkioIOTimeRecursive:         ns.NewLabeledGauge("blkio_io_time_recursive", "The blkio io time recursive", metrics.Total, "id", "op", "major", "minor"),
+		blkioSectorsRecursive:        ns.NewLabeledGauge("blkio_sectors_recursive", "The blkio sectors recursive", metrics.Total, "id", "op", "major", "minor"),
+	}
+}
+
+// Collector provides the ability to collect container stats and export
+// them in the prometheus format
+type Collector struct {
+	pidsLimit   metrics.LabeledGauge
+	pidsCurrent metrics.LabeledGauge
+
+	cpuTotal            metrics.LabeledGauge
+	cpuKernel           metrics.LabeledGauge
+	cpuUser             metrics.LabeledGauge
+	cpuPerCpu           metrics.LabeledGauge
+	cpuThrottlePeriods  metrics.LabeledGauge
+	cpuThrottledPeriods metrics.LabeledGauge
+	cpuThrottledTime    metrics.LabeledGauge
+
+	memoryCache metrics.LabeledGauge
+
+	memoryUsageLimit metrics.LabeledGauge
+	memoryUsageUsage metrics.LabeledGauge
+	memoryUsageMax   metrics.LabeledGauge
+	memoryUsageFail  metrics.LabeledGauge
+
+	memorySwapLimit metrics.LabeledGauge
+	memorySwapUsage metrics.LabeledGauge
+	memorySwapMax   metrics.LabeledGauge
+	memorySwapFail  metrics.LabeledGauge
+
+	memoryKernelLimit metrics.LabeledGauge
+	memoryKernelUsage metrics.LabeledGauge
+	memoryKernelMax   metrics.LabeledGauge
+	memoryKernelFail  metrics.LabeledGauge
+
+	memoryKernelTCPLimit metrics.LabeledGauge
+	memoryKernelTCPUsage metrics.LabeledGauge
+	memoryKernelTCPMax   metrics.LabeledGauge
+	memoryKernelTCPFail  metrics.LabeledGauge
+
+	hugetlbUsage metrics.LabeledGauge
+	hugetlbFail  metrics.LabeledGauge
+	hugetlbMax   metrics.LabeledGauge
+
+	blkioIOServiceBytesRecursive metrics.LabeledGauge
+	blkioIOServiedRecursive      metrics.LabeledGauge
+	blkioIOQueuedRecursive       metrics.LabeledGauge
+	blkioIOServiceTimeRecursive  metrics.LabeledGauge
+	blkioIOMergedRecursive       metrics.LabeledGauge
+	blkioIOTimeRecursive         metrics.LabeledGauge
+	blkioSectorsRecursive        metrics.LabeledGauge
+}
+
+func (c *Collector) Collect(id string, cg cgroups.Cgroup) error {
+	stats, err := cg.Stat()
+	if err != nil {
+		return err
+	}
+	if stats.Pids != nil {
+		c.pidsLimit.WithValues(id).Set(float64(stats.Pids.Limit))
+		c.pidsCurrent.WithValues(id).Set(float64(stats.Pids.Current))
+	}
+	if stats.Cpu != nil {
+		c.cpuTotal.WithValues(id).Set(float64(stats.Cpu.Usage.Total))
+		c.cpuKernel.WithValues(id).Set(float64(stats.Cpu.Usage.Kernel))
+		c.cpuUser.WithValues(id).Set(float64(stats.Cpu.Usage.User))
+		// set per cpu usage
+		for i, cpu := range stats.Cpu.Usage.PerCpu {
+			c.cpuPerCpu.WithValues(id, strconv.Itoa(i)).Set(float64(cpu))
+		}
+		c.cpuThrottlePeriods.WithValues(id).Set(float64(stats.Cpu.Throttling.Periods))
+		c.cpuThrottledPeriods.WithValues(id).Set(float64(stats.Cpu.Throttling.ThrottledPeriods))
+		c.cpuThrottledTime.WithValues(id).Set(float64(stats.Cpu.Throttling.ThrottledTime))
+	}
+	if stats.Memory != nil {
+		c.memoryCache.WithValues(id).Set(float64(stats.Memory.Cache))
+
+		c.memoryUsageFail.WithValues(id).Set(float64(stats.Memory.Usage.Failcnt))
+		c.memoryUsageLimit.WithValues(id).Set(float64(stats.Memory.Usage.Limit))
+		c.memoryUsageMax.WithValues(id).Set(float64(stats.Memory.Usage.Max))
+		c.memoryUsageUsage.WithValues(id).Set(float64(stats.Memory.Usage.Usage))
+
+		c.memorySwapFail.WithValues(id).Set(float64(stats.Memory.Swap.Failcnt))
+		c.memorySwapLimit.WithValues(id).Set(float64(stats.Memory.Swap.Limit))
+		c.memorySwapMax.WithValues(id).Set(float64(stats.Memory.Swap.Max))
+		c.memorySwapUsage.WithValues(id).Set(float64(stats.Memory.Swap.Usage))
+
+		c.memoryKernelFail.WithValues(id).Set(float64(stats.Memory.Kernel.Failcnt))
+		c.memoryKernelLimit.WithValues(id).Set(float64(stats.Memory.Kernel.Limit))
+		c.memoryKernelMax.WithValues(id).Set(float64(stats.Memory.Kernel.Max))
+		c.memoryKernelUsage.WithValues(id).Set(float64(stats.Memory.Kernel.Usage))
+
+		c.memoryKernelTCPFail.WithValues(id).Set(float64(stats.Memory.KernelTCP.Failcnt))
+		c.memoryKernelTCPLimit.WithValues(id).Set(float64(stats.Memory.KernelTCP.Limit))
+		c.memoryKernelTCPMax.WithValues(id).Set(float64(stats.Memory.KernelTCP.Max))
+		c.memoryKernelTCPUsage.WithValues(id).Set(float64(stats.Memory.KernelTCP.Usage))
+	}
+	if stats.Hugetlb != nil {
+		for k, v := range stats.Hugetlb {
+			c.hugetlbUsage.WithValues(id, k).Set(float64(v.Usage))
+			c.hugetlbFail.WithValues(id, k).Set(float64(v.Failcnt))
+			c.hugetlbMax.WithValues(id, k).Set(float64(v.Max))
+		}
+	}
+	if stats.Blkio != nil {
+		for _, v := range []struct {
+			gauge   metrics.LabeledGauge
+			entries []cgroups.BlkioEntry
+		}{
+			{
+				gauge:   c.blkioIOMergedRecursive,
+				entries: stats.Blkio.IoMergedRecursive,
+			},
+			{
+				gauge:   c.blkioIOQueuedRecursive,
+				entries: stats.Blkio.IoQueuedRecursive,
+			},
+			{
+				gauge:   c.blkioIOServiceBytesRecursive,
+				entries: stats.Blkio.IoServiceBytesRecursive,
+			},
+			{
+				gauge:   c.blkioIOServiceTimeRecursive,
+				entries: stats.Blkio.IoServiceTimeRecursive,
+			},
+			{
+				gauge:   c.blkioIOServiedRecursive,
+				entries: stats.Blkio.IoServicedRecursive,
+			},
+			{
+				gauge:   c.blkioIOTimeRecursive,
+				entries: stats.Blkio.IoTimeRecursive,
+			},
+			{
+				gauge:   c.blkioSectorsRecursive,
+				entries: stats.Blkio.SectorsRecursive,
+			},
+		} {
+			setIO(id, v.gauge, v.entries)
+		}
+	}
+	return nil
+}
+
+func setIO(id string, gauge metrics.LabeledGauge, entries []cgroups.BlkioEntry) {
+	for _, i := range entries {
+		gauge.WithValues(id, i.Op, strconv.FormatUint(i.Major, 10), strconv.FormatUint(i.Minor, 10)).Set(float64(i.Value))
+	}
+}

--- a/prometheus/oom.go
+++ b/prometheus/oom.go
@@ -1,0 +1,110 @@
+package prometheus
+
+import (
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/crosbymichael/cgroups"
+	metrics "github.com/docker/go-metrics"
+)
+
+func NewOOMCollector(ns *metrics.Namespace) (*OOMCollector, error) {
+	fd, err := syscall.EpollCreate1(syscall.EPOLL_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	c := &OOMCollector{
+		fd:        fd,
+		memoryOOM: ns.NewLabeledGauge("memory_oom", "The number of times a container received an oom event", metrics.Total, "id"),
+		set:       make(map[uintptr]*oom),
+	}
+	go c.start()
+	return c, nil
+}
+
+type OOMCollector struct {
+	mu sync.Mutex
+
+	memoryOOM metrics.LabeledGauge
+	fd        int
+	set       map[uintptr]*oom
+}
+
+type oom struct {
+	id string
+	c  cgroups.Cgroup
+}
+
+func (o *OOMCollector) Monitor(id string, cg cgroups.Cgroup) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	fd, err := cg.OOMEventFD()
+	if err != nil {
+		return err
+	}
+	o.set[fd] = &oom{
+		id: id,
+		c:  cg,
+	}
+	// set the gague's default value
+	o.memoryOOM.WithValues(id).Set(0)
+	event := syscall.EpollEvent{
+		Fd:     int32(fd),
+		Events: syscall.EPOLLHUP | syscall.EPOLLIN | syscall.EPOLLERR,
+	}
+	if err := syscall.EpollCtl(o.fd, syscall.EPOLL_CTL_ADD, int(fd), &event); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close closes the epoll fd
+func (o *OOMCollector) Close() error {
+	return syscall.Close(int(o.fd))
+}
+
+func (o *OOMCollector) start() {
+	var events [128]syscall.EpollEvent
+	for {
+		n, err := syscall.EpollWait(o.fd, events[:], -1)
+		if err != nil {
+			if err == syscall.EINTR {
+				continue
+			}
+			logrus.WithField("error", err).Fatal("cgroups: epoll wait")
+		}
+		for i := 0; i < n; i++ {
+			o.process(uintptr(events[i].Fd), events[i].Events)
+		}
+	}
+}
+
+func (o *OOMCollector) process(fd uintptr, event uint32) {
+	// make sure to always flush the fd
+	flush(fd)
+
+	o.mu.Lock()
+	info, ok := o.set[fd]
+	if !ok {
+		o.mu.Unlock()
+		return
+	}
+	o.mu.Unlock()
+	// if we received an event but it was caused by the cgroup being deleted and the fd
+	// being closed make sure we close our copy and remove the container from the set
+	if info.c.State() == cgroups.Deleted {
+		o.mu.Lock()
+		delete(o.set, fd)
+		o.mu.Unlock()
+		syscall.Close(int(fd))
+		return
+	}
+	o.memoryOOM.WithValues(info.id).Inc(1)
+}
+
+func flush(fd uintptr) error {
+	buf := make([]byte, 8)
+	_, err := syscall.Read(int(fd), buf)
+	return err
+}

--- a/stats.go
+++ b/stats.go
@@ -20,20 +20,18 @@ type HugetlbStat struct {
 
 type PidsStat struct {
 	Current uint64
-	Max     uint64
+	Limit   uint64
 }
 
 type CpuStat struct {
 	Usage      CpuUsage
 	Throttling Throttle
-	Cpus       string
-	Mems       string
 }
 
 type CpuUsage struct {
 	// Units: nanoseconds.
 	Total  uint64
-	Percpu []uint64
+	PerCpu []uint64
 	Kernel uint64
 	User   uint64
 }
@@ -50,7 +48,8 @@ type MemoryStat struct {
 	Swap      MemoryEntry
 	Kernel    MemoryEntry
 	KernelTCP MemoryEntry
-	Raw       map[string]uint64
+	// TODO: remove Raw and add type safe entries for the rest of the values
+	Raw map[string]uint64
 }
 
 type MemoryEntry struct {


### PR DESCRIPTION
This adds a collector that will export cgroup metrics to prometheus

This is a sample output for the metrics provided:

```
# HELP containerd_container_blkio_io_service_bytes_recursive_bytes The blkio io service bytes recursive
# TYPE containerd_container_blkio_io_service_bytes_recursive_bytes gauge
containerd_container_blkio_io_service_bytes_recursive_bytes{id="test",major="8",minor="0",op="Async"} 241664
containerd_container_blkio_io_service_bytes_recursive_bytes{id="test",major="8",minor="0",op="Read"} 241664
containerd_container_blkio_io_service_bytes_recursive_bytes{id="test",major="8",minor="0",op="Sync"} 0
containerd_container_blkio_io_service_bytes_recursive_bytes{id="test",major="8",minor="0",op="Total"} 241664
containerd_container_blkio_io_service_bytes_recursive_bytes{id="test",major="8",minor="0",op="Write"} 0
# HELP containerd_container_blkio_io_serviced_recursive_total The blkio io serviced recursive
# TYPE containerd_container_blkio_io_serviced_recursive_total gauge
containerd_container_blkio_io_serviced_recursive_total{id="test",major="8",minor="0",op="Async"} 11
containerd_container_blkio_io_serviced_recursive_total{id="test",major="8",minor="0",op="Read"} 11
containerd_container_blkio_io_serviced_recursive_total{id="test",major="8",minor="0",op="Sync"} 0
containerd_container_blkio_io_serviced_recursive_total{id="test",major="8",minor="0",op="Total"} 11
containerd_container_blkio_io_serviced_recursive_total{id="test",major="8",minor="0",op="Write"} 0
# HELP containerd_container_cpu_kernel_nanoseconds The total kernel cpu time
# TYPE containerd_container_cpu_kernel_nanoseconds gauge
containerd_container_cpu_kernel_nanoseconds{id="test"} 1e+07
# HELP containerd_container_cpu_throttle_periods_total The total throttle periods
# TYPE containerd_container_cpu_throttle_periods_total gauge
containerd_container_cpu_throttle_periods_total{id="test"} 0
# HELP containerd_container_cpu_throttled_periods_total The total throttled periods
# TYPE containerd_container_cpu_throttled_periods_total gauge
containerd_container_cpu_throttled_periods_total{id="test"} 0
# HELP containerd_container_cpu_throttled_time_nanoseconds The total throttled time
# TYPE containerd_container_cpu_throttled_time_nanoseconds gauge
containerd_container_cpu_throttled_time_nanoseconds{id="test"} 0
# HELP containerd_container_cpu_total_nanoseconds The total cpu time
# TYPE containerd_container_cpu_total_nanoseconds gauge
containerd_container_cpu_total_nanoseconds{id="test"} 1.9259673e+07
# HELP containerd_container_cpu_user_nanoseconds The total user cpu time
# TYPE containerd_container_cpu_user_nanoseconds gauge
containerd_container_cpu_user_nanoseconds{id="test"} 0
# HELP containerd_container_hugetlb_fail_total The hugetlb failcnt
# TYPE containerd_container_hugetlb_fail_total gauge
containerd_container_hugetlb_fail_total{id="test",page="1GB"} 0
containerd_container_hugetlb_fail_total{id="test",page="2MB"} 0
# HELP containerd_container_hugetlb_max_bytes The hugetlb max usage
# TYPE containerd_container_hugetlb_max_bytes gauge
containerd_container_hugetlb_max_bytes{id="test",page="1GB"} 0
containerd_container_hugetlb_max_bytes{id="test",page="2MB"} 0
# HELP containerd_container_hugetlb_usage_bytes The hugetlb usage
# TYPE containerd_container_hugetlb_usage_bytes gauge
containerd_container_hugetlb_usage_bytes{id="test",page="1GB"} 0
containerd_container_hugetlb_usage_bytes{id="test",page="2MB"} 0
# HELP containerd_container_memory_cache_bytes The cache amount used by the container
# TYPE containerd_container_memory_cache_bytes gauge
containerd_container_memory_cache_bytes{id="test"} 237568
# HELP containerd_container_memory_kernel_fail_total The kernel failcnt
# TYPE containerd_container_memory_kernel_fail_total gauge
containerd_container_memory_kernel_fail_total{id="test"} 0
# HELP containerd_container_memory_kernel_limit_bytes The kernel limit
# TYPE containerd_container_memory_kernel_limit_bytes gauge
containerd_container_memory_kernel_limit_bytes{id="test"} 9.223372036854772e+18
# HELP containerd_container_memory_kernel_max_bytes The kernel memory used
# TYPE containerd_container_memory_kernel_max_bytes gauge
containerd_container_memory_kernel_max_bytes{id="test"} 0
# HELP containerd_container_memory_kernel_tcp_fail_total The kernel tcp failcnt
# TYPE containerd_container_memory_kernel_tcp_fail_total gauge
containerd_container_memory_kernel_tcp_fail_total{id="test"} 0
# HELP containerd_container_memory_kernel_tcp_limit_bytes The kernel tcp limit
# TYPE containerd_container_memory_kernel_tcp_limit_bytes gauge
containerd_container_memory_kernel_tcp_limit_bytes{id="test"} 9.223372036854772e+18
# HELP containerd_container_memory_kernel_tcp_max_bytes The kernel tcp memory used
# TYPE containerd_container_memory_kernel_tcp_max_bytes gauge
containerd_container_memory_kernel_tcp_max_bytes{id="test"} 0
# HELP containerd_container_memory_kernel_tcp_usage_bytes The kernel tcp memory used
# TYPE containerd_container_memory_kernel_tcp_usage_bytes gauge
containerd_container_memory_kernel_tcp_usage_bytes{id="test"} 0
# HELP containerd_container_memory_kernel_usage_bytes The kernel memory used
# TYPE containerd_container_memory_kernel_usage_bytes gauge
containerd_container_memory_kernel_usage_bytes{id="test"} 0
# HELP containerd_container_memory_swap_fail_total The swap failcnt
# TYPE containerd_container_memory_swap_fail_total gauge
containerd_container_memory_swap_fail_total{id="test"} 0
# HELP containerd_container_memory_swap_limit_bytes The swap limit
# TYPE containerd_container_memory_swap_limit_bytes gauge
containerd_container_memory_swap_limit_bytes{id="test"} 9.223372036854772e+18
# HELP containerd_container_memory_swap_max_bytes The swap memory used
# TYPE containerd_container_memory_swap_max_bytes gauge
containerd_container_memory_swap_max_bytes{id="test"} 708608
# HELP containerd_container_memory_swap_usage_bytes The swap memory used
# TYPE containerd_container_memory_swap_usage_bytes gauge
containerd_container_memory_swap_usage_bytes{id="test"} 315392
# HELP containerd_container_memory_usage_fail_total The usage failcnt
# TYPE containerd_container_memory_usage_fail_total gauge
containerd_container_memory_usage_fail_total{id="test"} 0
# HELP containerd_container_memory_usage_limit_bytes The memory limit
# TYPE containerd_container_memory_usage_limit_bytes gauge
containerd_container_memory_usage_limit_bytes{id="test"} 9.223372036854772e+18
# HELP containerd_container_memory_usage_max_bytes The max memory used
# TYPE containerd_container_memory_usage_max_bytes gauge
containerd_container_memory_usage_max_bytes{id="test"} 708608
# HELP containerd_container_memory_usage_usage_bytes The current memory used
# TYPE containerd_container_memory_usage_usage_bytes gauge
containerd_container_memory_usage_usage_bytes{id="test"} 315392
# HELP containerd_container_per_cpu_nanoseconds The total cpu time per cpu
# TYPE containerd_container_per_cpu_nanoseconds gauge
containerd_container_per_cpu_nanoseconds{core="0",id="test"} 3.660724e+06
containerd_container_per_cpu_nanoseconds{core="1",id="test"} 4.254817e+06
containerd_container_per_cpu_nanoseconds{core="2",id="test"} 6.528155e+06
containerd_container_per_cpu_nanoseconds{core="3",id="test"} 4.815977e+06
# HELP containerd_container_pids_current The current number of pids
# TYPE containerd_container_pids_current gauge
containerd_container_pids_current{id="test"} 1
# HELP containerd_container_pids_limit The maximum number of pids allowed
# TYPE containerd_container_pids_limit gauge
containerd_container_pids_limit{id="test"} 0
```

I used this simple app to for collecting cgroups from any type of container:

```go
package main

import (
	"log"
	"net/http"
	"os"
	"time"

	"github.com/crosbymichael/cgroups"
	"github.com/crosbymichael/cgroups/prometheus"
	metrics "github.com/docker/go-metrics"
	"github.com/gorilla/mux"
)

func main() {
	path, name := os.Args[1], os.Args[2]
	c, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(path))
	if err != nil {
		log.Fatal(err)
	}
	ns := metrics.NewNamespace("containerd", "container", nil)
	cltr := prometheus.New(ns)
	metrics.Register(ns)
	go func() {
		for range time.Tick(5 * time.Second) {
			log.Println("collecting metrics")
			if err := cltr.Collect(name, c); err != nil {
				log.Fatal(err)
			}
		}
	}()
	m := mux.NewRouter()
	m.Handle("/metrics", metrics.Handler())
	if err := http.ListenAndServe("127.0.0.1:9876", m); err != nil {
		log.Fatal(err)
	}
}
```